### PR TITLE
修复requestAsyncUseEventLoop中的uri与config中的错误配置

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -68,12 +68,14 @@ abstract class AbstractProvider
     public function __construct(NacosClient $client, ?array $config = null)
     {
         $this->client = $client;
-        $config = $this->client->getConfigs() ??
-            (
-                function_exists('config') ?
+        $config = empty($this->client->getConfigs())
+            ? (
+            function_exists('config') ?
                 config('plugin.workbunny.webman-nacos.app', $config) :
                 $config
-            );
+            )
+            : $this->client->getConfigs();
+
         isset($config['host']) && $this->host = (string) $config['host'];
         isset($config['port']) && $this->port = (int) $config['port'];
         isset($config['username']) && $this->username = (string) $config['username'];
@@ -206,7 +208,7 @@ abstract class AbstractProvider
                 'Connection' => 'keep-alive'
             ]);
             $this->httpClientAsync()->request(
-                sprintf('http://%s:%d%s?%s', $this->host, $this->port, $uri, $queryString),
+                sprintf('http://%s:%d/%s?%s', $this->host, $this->port, $uri, $queryString),
                 [
                     'method'    => $method,
                     'version'   => '1.1',


### PR DESCRIPTION
1. AbstractProvider类构造函数config为正确配置
2. requestAsyncUseEventLoop()中未正常替换url
`sprintf('http://%s:%d/%s?%s', $this->host, $this->port, $uri, $queryString),`