### PR TITLE
bug修复

### DIFF
--- a/src/Process/InstanceRegistrarProcess.php
+++ b/src/Process/InstanceRegistrarProcess.php
@@ -51,7 +51,7 @@ class InstanceRegistrarProcess extends AbstractProcess
                 $option['ephemeral'] = (is_string($option['ephemeral']) ? filter_var($option['ephemeral'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : (bool) $option['ephemeral'] );
             }
             // 仅对非永久实例进行心跳
-            if (!($option['ephemeral'] ?? false)) {
+            if ($option['ephemeral'] ?? false) {
                 $this->heartbeatTimers[$name] = Timer::add($this->heartbeat, function () use ($name) {
                     list($serviceName, $ip, $port, $option) = $this->instanceRegistrars[$name];
                     if (isset($option['ephemeral'])) {

--- a/src/Process/InstanceRegistrarProcess.php
+++ b/src/Process/InstanceRegistrarProcess.php
@@ -54,7 +54,9 @@ class InstanceRegistrarProcess extends AbstractProcess
             if (!($option['ephemeral'] ?? false)) {
                 $this->heartbeatTimers[$name] = Timer::add($this->heartbeat, function () use ($name) {
                     list($serviceName, $ip, $port, $option) = $this->instanceRegistrars[$name];
-
+                    if (isset($option['ephemeral'])) {
+                        $option['ephemeral'] = (is_string($option['ephemeral']) ? filter_var($option['ephemeral'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : (bool) $option['ephemeral'] );
+                    }
                     try {
                         if(!$this->client->instance->beat(
                             $serviceName,


### PR DESCRIPTION
感谢您这两天在webman上面的解答，再次感谢
升级到1.2.3后，出现了2个bug
1、InstanceRegistrarProcess的第54行的判断，逻辑正好相反，判断临时实例，是用true，而不是false。
2、因为默认的app.php文件中ephemeral的值还是字符串类型。
InstanceRegistrarProcess还是这个文件，第56行的list($serviceName, $ip, $port, $option) = $this->instanceRegistrars[$name];
会导致，前面$option['ephemeral']转换成的布尔值，再次被换成字符串，进而导致InstanceProvider文件的beat方法报错，因为第5个参数ephemeral需要是布尔值
该pr已经尝试修复了上述问题，谢谢