### PR TITLE
注册服务时enabled的值转字符串

### DIFF
--- a/src/Process/InstanceRegistrarProcess.php
+++ b/src/Process/InstanceRegistrarProcess.php
@@ -101,6 +101,7 @@ class InstanceRegistrarProcess extends AbstractProcess
                 foreach ($instanceRegistrars as $name => $instanceRegistrar){
                     // 拆解配置
                     list($serviceName, $ip, $port, $option) = $instanceRegistrar;
+                    $option['enabled'] = is_bool($option['enabled']) ? ($option['enabled'] ? 'true' : 'false') : $option['enabled'];
                     // 注册
                     $promises[] = $this->client->instance->registerAsync($ip, $port, $serviceName, $option)
                         ->then(function (ResponseInterface $response) use ($instanceRegistrar, $name) {


### PR DESCRIPTION
主要是解决服务注册的时候，enabled为布尔类型，导致该字段无效的问题。
目前enabled配置了true，但是在使用过程中发现服务实例并未上线